### PR TITLE
fix: correct API docs port from 8080 to 3000

### DIFF
--- a/api.docs.yaml
+++ b/api.docs.yaml
@@ -4,7 +4,7 @@ info:
   version: 1.0.0
   description: API pour gérer l'authentification et les revenus des utilisateurs.
 servers:
-  - url: http://localhost:8080/api
+  - url: http://localhost:3000/api
 
 paths:
   /auth/signup:


### PR DESCRIPTION
docs port might be 3000 like the backend not 3000